### PR TITLE
Support for proxmox 8

### DIFF
--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -122,7 +122,7 @@ class ProxmoxPoolList(list):
 
 class ProxmoxVersion(dict):
     def get_version(self):
-        return float(self['version'].split('-')[0])
+        return float(self['version'].split('-')[0][:3])
 
 
 class ProxmoxPool(dict):


### PR DESCRIPTION
Support for proxmox 8 as the version numbers now are reported as 8.4.x, so this will enforce that only a float is actually retuned like 8.4